### PR TITLE
Switch Bithumb trading to JWT authentication

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ aiohttp>=3.9
 pandas>=2.2
 numpy>=1.26
 pytz>=2024.1
+PyJWT>=2.0


### PR DESCRIPTION
## Summary
- replace deprecated HMAC signing with JWT headers
- use new /v1/accounts and /v1/orders endpoints for market trades
- add PyJWT dependency

## Testing
- `python -m py_compile coint.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6d927058c8329a24bd103bb4e22b8